### PR TITLE
Add customer teardown in corresponding tests

### DIFF
--- a/cypress/integration/storefront/account/register.spec.js
+++ b/cypress/integration/storefront/account/register.spec.js
@@ -13,7 +13,7 @@ describe('Register: Open register form', function () {
         cy.get('.register-submit [type="submit"]').click();
     });
 
-    it('fill form', function () {
+    it('fill registration form and submit', function () {
         cy.visit('/account/login');
 
         cy.get('select[name="salutationId"]').select('Mx.');
@@ -25,7 +25,7 @@ describe('Register: Open register form', function () {
         cy.get('select[name="birthdayMonth"]').select('8');
         cy.get('select[name="birthdayYear"]').select('1917');
 
-        cy.get('.register-form input[name="email"]').type('john+'+Math.random() * 100+'@example.com');
+        cy.get('.register-form input[name="email"]').type('john-doe-for-testing@example.com');
         cy.get('.register-form input[name="password"]').type('1234567890');
 
         cy.get('input[name="billingAddress[street]"]').type('123 Main St');
@@ -41,5 +41,10 @@ describe('Register: Open register form', function () {
         cy.get('.account-welcome h1').should((element) => {
             expect(element).to.contain('Prof. Dr.');
         });
+    });
+    after(function () {
+        return cy.removeFixtureByName('john-doe-for-testing@example.com', 'customer', {
+            identifier: 'email'
+        })
     });
 });

--- a/cypress/integration/storefront/checkout/checkout-run.spec.js
+++ b/cypress/integration/storefront/checkout/checkout-run.spec.js
@@ -21,7 +21,7 @@ describe('Home: Open home page', function () {
         cy.get('select[name="birthdayMonth"]').select('8');
         cy.get('select[name="birthdayYear"]').select('1917');
 
-        cy.get('.register-form input[name="email"]').type('john+' + Math.random() * 100 + '@example.com');
+        cy.get('.register-form input[name="email"]').type('john-doe-for-testing@example.com');
         cy.get('.register-form input[name="password"]').type('1234567890');
 
         cy.get('input[name="billingAddress[street]"]').type('123 Main St');
@@ -58,5 +58,10 @@ describe('Home: Open home page', function () {
         * cy.get('#confirmFormSubmit').click();
         * cy.get('.finish-header').contains('Thank you for your order with Shopware Storefront!');
         */
+    });
+    after(function () {
+        return cy.removeFixtureByName('john-doe-for-testing@example.com', 'customer', {
+            identifier: 'email'
+        })
     });
 });

--- a/cypress/support/commands/api-commands.js
+++ b/cypress/support/commands/api-commands.js
@@ -59,7 +59,6 @@ Cypress.Commands.add("loginViaApi", () => {
     });
 });
 
-
 /**
  * Handling API requests
  * @memberOf Cypress.Chainable#
@@ -181,7 +180,6 @@ Cypress.Commands.add("deleteViaAdminApi", (endpoint, id) => {
         return responseData;
     });
 });
-
 
 /**
  * Updates an existing entity using Shopware API at the given endpoint


### PR DESCRIPTION
This PR adds some teardown in registration- and checkout-tests, removing test customer data if necessary.