### PR TITLE
Update storefront api command

### DIFF
--- a/cypress/support/commands/storefront-api-commands.js
+++ b/cypress/support/commands/storefront-api-commands.js
@@ -46,7 +46,7 @@ Cypress.Commands.add('storefrontApiRequest', (method, endpoint, header = {}, bod
                 ...body
             },
             method: method,
-            url: `/storefront-api/v1/${endpoint}`,
+            url: `/sales-channel-api/v1/${endpoint}`,
         };
 
         return cy.request(requestConfig).then((result) => {


### PR DESCRIPTION
Update API endpoint to match the current `/sales-channel-api` url.